### PR TITLE
Potential fix for code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/docs/source/_static/js/version-picker.js
+++ b/docs/source/_static/js/version-picker.js
@@ -56,7 +56,25 @@ document.addEventListener("DOMContentLoaded", function () {
 
   // Navigate to the selected version on change
   dropdown.addEventListener("change", function () {
-    window.location.href = this.value;
+    const selectedValue = this.value;
+    if (!selectedValue) {
+      return;
+    }
+
+    try {
+      // Normalize relative URLs against the current origin
+      const targetUrl = new URL(selectedValue, window.location.origin);
+
+      // Only allow navigation to http(s) URLs
+      if (targetUrl.protocol === "http:" || targetUrl.protocol === "https:") {
+        window.location.href = targetUrl.toString();
+      } else {
+        console.error("Blocked navigation to unsafe URL scheme:", targetUrl.href);
+      }
+    } catch (e) {
+      // If the value is not a valid URL, do not navigate
+      console.error("Invalid URL in version picker:", selectedValue, e);
+    }
   });
 
   // Add elements to the version picker


### PR DESCRIPTION
Potential fix for [https://github.com/duckframework/duck/security/code-scanning/7](https://github.com/duckframework/duck/security/code-scanning/7)

In general, the fix is to ensure that the value taken from the DOM (`this.value` / `version.url`) is validated or constrained before it is used to change `window.location.href`. Rather than blindly trusting whatever URL is in the `<option>`’s `value`, we should only allow safe, expected URLs—for example, relative paths within the same site, or absolute URLs with `http:` or `https:` schemes and (optionally) a matching host.

The best minimal fix, without changing the user-facing functionality, is to validate `this.value` inside the `change` event handler and only navigate if it is a safe HTTP(S) URL or a relative URL. We can do this by:

1. Creating a `URL` object with `new URL(this.value, window.location.origin)` to normalize relative paths against the current origin.
2. Checking the resulting `url.protocol` is `http:` or `https:` (rejecting `javascript:`, `data:`, `vbscript:`, etc.).
3. Optionally ensuring the URL belongs to the same origin (if desired), but that is not strictly required for basic XSS safety.
4. Only then assigning `window.location.href = safeUrl.toString()`.

All changes are confined to docs/source/_static/js/version-picker.js, in the `dropdown.addEventListener("change", ...)` block around line 58–60. No additional imports are necessary because `URL` is part of the standard Web API.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
