### PR TITLE
Potential fix for code scanning alert no. 13: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -4,10 +4,6 @@ on:
   push:
     tags:
       - "v*.*.*"          # publish only when version tags are pushed
-  workflow_run:
-    workflows: ["Publish to TestPyPI"]
-    types:
-      - completed
   workflow_dispatch:
     inputs:
       tag:
@@ -94,7 +90,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
       with:
-        ref: ${{ inputs.tag || (github.event_name == 'workflow_run' && github.event.workflow_run.head_sha) || github.ref }}
+        ref: ${{ inputs.tag || github.ref }}
         persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@v6


### PR DESCRIPTION
Potential fix for [https://github.com/duckframework/duck/security/code-scanning/13](https://github.com/duckframework/duck/security/code-scanning/13)

Best fix: do not run this PyPI publish workflow from `workflow_run`. Keep only trusted/manual/tag triggers so the workflow runs from explicitly trusted refs.

In `.github/workflows/pypi-publish.yml`:
- Remove the `workflow_run` trigger block under `on:`.
- Simplify checkout `ref` to avoid referencing `github.event.workflow_run.head_sha`; use only `inputs.tag` (manual) or `github.ref` (tag push).

This preserves intended functionality (publish by tag push or manual dispatch) while removing the untrusted trigger path.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
