### PR TITLE
Potential fix for code scanning alert no. 19: DOM text reinterpreted as HTML

### DIFF
--- a/duck/etc/templates/base.html
+++ b/duck/etc/templates/base.html
@@ -848,6 +848,15 @@
     }
 
     // Highlight key parts of the traceback for faster scanning
+    function escapeHtml(str) {
+      return str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
     (function colourTraceback() {
       const pre = document.getElementById('traceback-pre');
       if (!pre) return;
@@ -856,21 +865,23 @@
       const lines = raw.split('\n');
 
       const html = lines.map(function (line) {
+        const safeLine = escapeHtml(line);
+
         // File reference lines — "  File "path/to/file.py", line N, in fn"
         if (/^\s*File ".+", line \d+/.test(line)) {
-          return line
+          return safeLine
             .replace(/(File ")([^"]+)(", line )(\d+)/,
               '<span class="tb-file">$1$2$3</span><span class="tb-lineno">$4</span>');
         }
         // Final error line — "ExceptionType: message"
         if (/^[A-Z][a-zA-Z0-9_]*(\.[A-Z][a-zA-Z0-9_]*)*:\s/.test(line.trim())) {
-          return `<span class="tb-error">${line}</span>`;
+          return `<span class="tb-error">${safeLine}</span>`;
         }
         // Code lines inside a frame — indented non-File lines
         if (/^\s{4}[^\s]/.test(line)) {
-          return `<span class="tb-code">${line}</span>`;
+          return `<span class="tb-code">${safeLine}</span>`;
         }
-        return line;
+        return safeLine;
       });
 
       pre.innerHTML = html.join('\n');


### PR DESCRIPTION
Potential fix for [https://github.com/duckframework/duck/security/code-scanning/19](https://github.com/duckframework/duck/security/code-scanning/19)

Use HTML escaping for all traceback text segments before building the highlighted markup, so only the intentionally added `<span>` wrappers are interpreted as HTML.

Best fix in `duck/etc/templates/base.html` (in the `<script>` block around lines 850–877):

1. Add a small local helper, e.g. `escapeHtml(str)`, that escapes `&`, `<`, `>`, `"`, `'`.
2. In `colourTraceback()`, escape each `line` first (`const safeLine = escapeHtml(line)`).
3. Run regex tests on the original `line` (to preserve matching behavior), but build returned HTML using `safeLine`.
4. For the file/line replacement branch, apply `.replace(...)` to `safeLine` so captured groups are escaped text, then wrapped in spans.
5. Keep `pre.innerHTML = html.join('\n');` unchanged, since content is now safely encoded except for controlled span tags.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
